### PR TITLE
Fix namespace dispatch API path

### DIFF
--- a/workers.go
+++ b/workers.go
@@ -277,7 +277,7 @@ func (api *API) UploadWorker(ctx context.Context, rc *ResourceContainer, params 
 
 	uri := fmt.Sprintf("/accounts/%s/workers/scripts/%s", rc.Identifier, params.ScriptName)
 	if params.DispatchNamespaceName != nil {
-		uri = fmt.Sprintf("/accounts/%s/workers/namespaces/%s/scripts/%s", rc.Identifier, *params.DispatchNamespaceName, params.ScriptName)
+		uri = fmt.Sprintf("/accounts/%s/workers/dispatch/namespaces/%s/scripts/%s", rc.Identifier, *params.DispatchNamespaceName, params.ScriptName)
 	}
 
 	headers := make(http.Header)

--- a/workers_test.go
+++ b/workers_test.go
@@ -1217,7 +1217,7 @@ func TestUploadWorker_ToDispatchNamespace(t *testing.T) {
 		fmt.Fprint(w, workersScriptResponse(t))
 	}
 	mux.HandleFunc(
-		fmt.Sprintf("/accounts/"+testAccountID+"/workers/namespaces/%s/scripts/bar", namespaceName),
+		fmt.Sprintf("/accounts/"+testAccountID+"/workers/dispatch/namespaces/%s/scripts/bar", namespaceName),
 		handler,
 	)
 


### PR DESCRIPTION
## Description
As per the [API documentation](https://developers.cloudflare.com/cloudflare-for-platforms/workers-for-platforms/get-started/configuration/#2-create-dispatcher), the path should have `/dispatch` when deploying to the namespaced dispatch API.

Otherwise, we had the following error:

```
error uploading worker '123-456-abcdefghi': PUT method not allowed for the api_token authentication scheme (10000)
```

Upon adding `/dispatch` into the URL, we got successful responses.

## Types of changes

What sort of change does your code introduce/modify?

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] This change is using publicly documented in [cloudflare/api-schemas](https://github.com/cloudflare/api-schemas) 
      and relies on stable APIs.

[1]: https://help.github.com/articles/closing-issues-using-keywords/
